### PR TITLE
Add JSON for Spraggins IMS dataset

### DIFF
--- a/fake-files/output-expected/spraggins/spraggins.ims.json
+++ b/fake-files/output-expected/spraggins/spraggins.ims.json
@@ -4,5 +4,9 @@
     "x",
     "y"
   ],
-  "zarrSource": "https://s3.amazonaws.com/vitessce-data/0.0.20/master_release/spraggins/spraggins.ims.zarr"
+  "zarrConfig": {
+    "store": "https://s3.amazonaws.com/vitessce-data/0.0.20/master_release/spraggins/",
+    "path": "spraggins.ims.zarr",
+    "mode": "r"
+  }
 }

--- a/fake-files/output-expected/spraggins/spraggins.ims.json
+++ b/fake-files/output-expected/spraggins/spraggins.ims.json
@@ -1,0 +1,8 @@
+{
+  "dimensions": [
+    "mz",
+    "x",
+    "y"
+  ],
+  "zarrSource": "https://s3.amazonaws.com/vitessce-data/0.0.20/master_release/spraggins/spraggins.ims.zarr"
+}

--- a/fake-files/output-expected/spraggins/spraggins.ims.json
+++ b/fake-files/output-expected/spraggins/spraggins.ims.json
@@ -6,7 +6,6 @@
   ],
   "zarrConfig": {
     "store": "https://s3.amazonaws.com/vitessce-data/0.0.20/master_release/spraggins/",
-    "path": "spraggins.ims.zarr",
-    "mode": "r"
+    "path": "spraggins.ims.zarr"
   }
 }

--- a/python/imzml_reader.py
+++ b/python/imzml_reader.py
@@ -134,10 +134,11 @@ def write_metadata_json(json_file):
     s3_target = open("s3_target.txt").read().strip()
     json_out = {
         "dimensions": ["mz", "x", "y"],
-        "zarrSource": (
-            f"https://s3.amazonaws.com/{s3_target}"
-            f"/spraggins/spraggins.ims.zarr"
-        ),
+        "zarrConfig": {
+            "store": f"https://s3.amazonaws.com/{s3_target}/spraggins/",
+            "path": "spraggins.ims.zarr",
+            "mode": "r",
+        },
     }
     json.dump(json_out, json_file, indent=2)
 

--- a/python/imzml_reader.py
+++ b/python/imzml_reader.py
@@ -137,7 +137,6 @@ def write_metadata_json(json_file):
         "zarrConfig": {
             "store": f"https://s3.amazonaws.com/{s3_target}/spraggins/",
             "path": "spraggins.ims.zarr",
-            "mode": "r",
         },
     }
     json.dump(json_out, json_file, indent=2)
@@ -162,8 +161,9 @@ if __name__ == "__main__":
         required=True,
         help="Write the IMS data to this zarr file.",
     )
+    # FileType('x'): exclusive file creation, fails if file already exits.
     parser.add_argument(
-        "--ims_file",
+        "--ims_metadata",
         type=argparse.FileType("x"),
         required=True,
         help="Write the metadata about the IMS zarr store on S3.",
@@ -174,4 +174,4 @@ if __name__ == "__main__":
         args.imzml_file, args.ibd_file, micro_res=0.5, ims_res=10
     )
     dataset.write_zarr(args.ims_zarr, dtype="i4", compressor=Zlib(level=1))
-    write_metadata_json(args.ims_file)
+    write_metadata_json(args.ims_metadata)

--- a/python/imzml_reader.py
+++ b/python/imzml_reader.py
@@ -7,6 +7,7 @@ from numcodecs import Zlib
 import zarr
 
 import argparse
+import json
 from collections import namedtuple
 
 CoordExtent = namedtuple("CoordExtent", "x_min y_min x_max y_max")
@@ -129,6 +130,18 @@ class IMSDataset:
         z_arr.attrs["mz"] = self._format_mzs().tolist()
 
 
+def write_metadata_json(json_file):
+    s3_target = open("s3_target.txt").read().strip()
+    json_out = {
+        "dimensions": ["mz", "x", "y"],
+        "zarrSource": (
+            f"https://s3.amazonaws.com/{s3_target}"
+            f"/spraggins/spraggins.ims.zarr"
+        ),
+    }
+    json.dump(json_out, json_file, indent=2)
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Create zarr from Spraggins dataset."
@@ -144,12 +157,20 @@ if __name__ == "__main__":
         help="Corresponding ibd file from Jeff Spraggins' lab",
     )
     parser.add_argument(
-        "--ims_file",
+        "--ims_zarr",
         required=True,
         help="Write the IMS data to this zarr file.",
     )
+    parser.add_argument(
+        "--ims_file",
+        type=argparse.FileType("x"),
+        required=True,
+        help="Write the metadata about the IMS zarr store on S3.",
+    )
     args = parser.parse_args()
+
     dataset = IMSDataset(
         args.imzml_file, args.ibd_file, micro_res=0.5, ims_res=10
     )
-    dataset.write_zarr(args.ims_file, dtype="i4", compressor=Zlib(level=1))
+    dataset.write_zarr(args.ims_zarr, dtype="i4", compressor=Zlib(level=1))
+    write_metadata_json(args.ims_file)

--- a/scripts/process_spraggins.sh
+++ b/scripts/process_spraggins.sh
@@ -11,9 +11,9 @@ main() {
     IMZML_IN="$INPUT/spraggins.ims.imzml"
     IBD_IN="$INPUT/spraggins.ims.ibd"
     ZARR_OUT="$OUTPUT/spraggins.ims.zarr"
+    JSON_OUT="$OUTPUT/spraggins.ims.json"
 
-    CLI_ARGS="--imzml_file $IMZML_IN --ibd_file $IBD_IN --ims_zarr $ZARR_OUT"
-    add_CLI_ARGS 'ims' 'spraggins'
+    CLI_ARGS="--imzml_file $IMZML_IN --ibd_file $IBD_IN --ims_zarr $ZARR_OUT --ims_metadata $JSON_OUT"
 
     echo "Download and process IMS data..."
 

--- a/scripts/process_spraggins.sh
+++ b/scripts/process_spraggins.sh
@@ -4,7 +4,7 @@ set -o errexit
 . ./scripts/utils.sh
 
 main() {
-    # Download and process data which describes an imaging 
+    # Download and process data which describes an imaging
     # mass spectrometry (IMS) experiment. A single zarr store is created.
 
     get_CLI_args "$@"
@@ -12,7 +12,8 @@ main() {
     IBD_IN="$INPUT/spraggins.ims.ibd"
     ZARR_OUT="$OUTPUT/spraggins.ims.zarr"
 
-    CLI_ARGS="--imzml_file $IMZML_IN --ibd_file $IBD_IN --ims_file $ZARR_OUT"
+    CLI_ARGS="--imzml_file $IMZML_IN --ibd_file $IBD_IN --ims_zarr $ZARR_OUT"
+    add_CLI_ARGS 'ims' 'spraggins'
 
     echo "Download and process IMS data..."
 


### PR DESCRIPTION
- Vitessce ingests validated JSON at the top level, and this will serve a similar purpose as `linnarsson.images.json` to specify additional metadata and `zarrStore` source.

One thing to note:

Currently a `store` in `zarr.js` is initialized as follows:  

```javascript
import { openArray } from 'zarr';

const config = {
    store: 'https://s3.amazonaws.com/vitessce-data/0.0.20/master_release/spraggins/',
    path: 'spraggins.ims.zarr',
    mode: 'r'
}

const z = await openArray(config); 
```

Would it make sense to just include this config directly in `spraggins.ims.json`?
```
// spraggins.ims.json
{
  "dimensions": [
    "mz",
    "x",
    "y"
  ],
  "zarrConfig": {
     store: 'https://s3.amazonaws.com/vitessce-data/0.0.20/master_release/spraggins/',
     path: 'spraggins.ims.zarr',
     mode: 'r'
  }
}
```