### PR TITLE
Fix untar bug and python open() bug

### DIFF
--- a/python/write_raster_metadata.py
+++ b/python/write_raster_metadata.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--raster_json",
-        type=argparse.FileType("x"),
+        type=argparse.FileType("w"),
         required=True,
         help="Write raster metadata into single output.",
     )

--- a/snakemake/satija/Snakefile
+++ b/snakemake/satija/Snakefile
@@ -103,7 +103,7 @@ rule untar_cells_data:
         )
     shell:
         '''
-        tar -xvzf {input} -C {RAW_DIR}
+        tar -xvf {input} -C {RAW_DIR}
         '''
 
 # Download TAR file containing UMAP clustering data.


### PR DESCRIPTION
Two minor bug fixes

- `argparse.FileType("x")` causes `process.sh` fails if the file exists
- for some reason `tar -xvzf` works on mac but not linux, so it fails on O2. `tar -xvf` work on both