### PR TITLE
add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Set up the `vitessce-data` environment using conda:
 ```sh
 conda env create -f environment.yml
 ```
+
+Users could also install the dependencies with pip via
+
+```sh
+pip install -r requirements.txt
+```
+
 ## Develop and run
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Set up the `vitessce-data` environment using conda:
 conda env create -f environment.yml
 ```
 
-Users could also install the dependencies with pip via
+Users may also install the dependencies with pip:
 
 ```sh
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,21 @@
+scikit-learn==0.20.3
+pandas==0.24.1
+flake8==3.6.0
+snakemake==5.20.1
+scipy==1.4.1
+h5py==2.10.0
+anndata==0.7.1
+pyarrow==0.15.1
+networkx==2.4
+loompy==2.0.16
+numcodecs==0.6.3 # 0.6.4 not working on MacOS: https://github.com/napari/napari/issues/665
+zarr==2.3.2
+dask==2.11.0
+toolz==0.9.0
+fsspec==0.3.3
+tifffile==2020.2.16
+iiif==1.0.6
+apeer-ometiff-library==1.3.1
+pyimzml==1.3.0
+scikit-image==0.16.2
+obonet==0.2.5


### PR DESCRIPTION
I'm using the master branch, but feel free to use a different branch. 

Related to: https://github.com/hubmapconsortium/vitessce-data/issues/111

* Add a `requirements.txt` for pip installation. 
* Notes in the README

There were two issues I came across:

* I changed the version of `scikit-image`, as I was getting the following error:
```
ERROR: Could not find a version that satisfies the requirement scikit-image==0.16.1 (from -r requirements.txt (line 20)) (from versions: 0.7.2, 0.8.0, 0.8.1, 0.8.2, 0.9.0, 0.9.1, 0.9.3, 0.10.0, 0.10.1, 0.11.2, 0.11.3, 0.12.0, 0.12.1, 0.12.2, 0.12.3, 0.13.0, 0.13.1, 0.14.0, 0.14.1, 0.14.2, 0.14.3, 0.14.5, 0.15.0, 0.16.2, 0.17.1, 0.17.2)
```
* The installation for `obonet` runs into issues via `wheezy.template`. This appears to be a problem noted elsewhere. It sticks on the following:
```
Collecting wheezy.template
  Using cached wheezy.template-0.1.195.tar.gz (17 kB)
```

Review request: @ilan-gold @keller-mark 